### PR TITLE
Ensure file removal succeed regardless of pre-existence

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,6 +73,8 @@ const generateFile = Effect.fn('generateFile')(function* ({
 
   const targetFilePath = path.join(cwd, targetFileName)
 
+  // We add the `force` flag here so the `remove` function does not return an error
+  // if the file did not exist initially.
   yield* fs.remove(targetFilePath, { force: true })
   yield* fs.writeFileString(targetFilePath, fileContentString)
   yield* Effect.log(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,7 +73,7 @@ const generateFile = Effect.fn('generateFile')(function* ({
 
   const targetFilePath = path.join(cwd, targetFileName)
 
-  yield* fs.remove(targetFilePath)
+  yield* fs.remove(targetFilePath, { force: true })
   yield* fs.writeFileString(targetFilePath, fileContentString)
   yield* Effect.log(
     `Generated ${targetFilePath} ${readOnly ? '(read-only)' : '(writable)'}`,


### PR DESCRIPTION
When creating a config file for the first time, ⁠genie crashed if the file did not exist. This PR ensures that the ⁠`fs.remove` call functions correctly even when the file does not exist.